### PR TITLE
fix: load nvim-cmp on entering cmdline

### DIFF
--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -15,7 +15,7 @@ return {
       "hrsh7th/nvim-cmp",
       "hrsh7th/cmp-nvim-lua",
       "hrsh7th/cmp-buffer",
-      "hrsh7th/cmp-cmdline",
+      { "hrsh7th/cmp-cmdline", lazy = false }, -- lazy = false is required to bind to restored buffers on startup
       "hrsh7th/cmp-nvim-lsp",
       "hrsh7th/cmp-nvim-lsp-document-symbol",
       "hrsh7th/cmp-path",

--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -11,11 +11,12 @@ return {
   { "github/copilot.vim", event = { "BufReadPost", "BufNewFile" } },
   {
     "hrsh7th/nvim-cmp",
+    event = { "InsertEnter", "CmdlineEnter" },
     dependencies = {
       "hrsh7th/nvim-cmp",
       "hrsh7th/cmp-nvim-lua",
       "hrsh7th/cmp-buffer",
-      { "hrsh7th/cmp-cmdline", lazy = false }, -- lazy = false is required to bind to restored buffers on startup
+      "hrsh7th/cmp-cmdline",
       "hrsh7th/cmp-nvim-lsp",
       "hrsh7th/cmp-nvim-lsp-document-symbol",
       "hrsh7th/cmp-path",


### PR DESCRIPTION
## The Problem
`cmp-cmdline` does not work right away when entering the cmdline without
entering a new buffer on session recovery.

### Steps to Reproduce
- Open `nvim` open a buffer for any file. `cmp-cmdline` works in the for commands and search.
- `:mksession session.vim` to save the session, exit nvim `:qa`
- Open `nvim` back up with the session file `nvim -S session.vim`
- Confirm that `cmp-cmdline` does not work right away without entering insert mode / opening a new buffer first.
- Open a new buffer, confirm that `cmp-cmdline` works with it.

## The Fix
We need to load `nvim-cmp` on the `EnterCmdline` even to ensure its ready in all cases.
